### PR TITLE
Fixed S3 lock prefix issue

### DIFF
--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/application/ExhibitorMain.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/application/ExhibitorMain.java
@@ -266,7 +266,7 @@ public class ExhibitorMain implements Closeable
             printHelp(options);
             return null;
         }
-        return new S3ConfigArguments(parts[0].trim(), parts[1].trim(), prefix, new S3ConfigAutoManageLockArguments(prefix + "_lock_"));
+        return new S3ConfigArguments(parts[0].trim(), parts[1].trim(), prefix, new S3ConfigAutoManageLockArguments(prefix + "-lock-"));
     }
 
     public ExhibitorMain(BackupProvider backupProvider, ConfigProvider configProvider, ExhibitorArguments arguments, int httpPort) throws Exception


### PR DESCRIPTION
The default lock prefix contained underscores, which caused S3 PseudoLockBase to throw and exception. I replaced the underscores with dashes and confirmed that it now works correctly.
