### PR TITLE
basic auth config for exhibitor-standalone

### DIFF
--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/application/ExhibitorMain.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/application/ExhibitorMain.java
@@ -96,11 +96,11 @@ public class ExhibitorMain implements Closeable
     private static final String DEFAULT_FILESYSTEMCONFIG_PREFIX = "exhibitor-";
     private static final String DEFAULT_FILESYSTEMCONFIG_LOCK_PREFIX = "exhibitor-lock-";
 
-    public static final String BASIC_AUTH_REALM = "basicauthrealm";
-    public static final String CONSOLE_USER = "consoleuser";
-    public static final String CURATOR_USER = "curatoruser";
-    public static final String CONSOLE_PASSWORD = "consolepassword";
-    public static final String CURATOR_PASSWORD = "curatorpassword";
+    private static final String BASIC_AUTH_REALM = "basicauthrealm";
+    private static final String CONSOLE_USER = "consoleuser";
+    private static final String CURATOR_USER = "curatoruser";
+    private static final String CONSOLE_PASSWORD = "consolepassword";
+    private static final String CURATOR_PASSWORD = "curatorpassword";
 
     public static void main(String[] args) throws Exception
     {


### PR DESCRIPTION
Add the ability to configure basic auth in exhibitor-standalone

Adds params basicauthrealm, consoleuser, consolepassword, curatoruser, curatorpassword

If all are set adds a Jetty security handler that grants total access to consoleuser:consolepassword and access to /exhibitor/v1/cluster/list to curatoruser:curatorpassword

Curator users that want to enable this basic auth would have to use a non default ExhibitorRestClient in their ExhibitorEnsembleProvider, which knows how to set the appropriate basic auth header.
