### PR TITLE
1.4.5

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+1.4.5 - January 9, 2013
+=======================
+* Issue 103: S3 buckets outside of us-east-1 now require an "endpoint" to be set. For the standalone
+version, use the new CLI --s3region <region>. e.g. "--s3region eu-west-1".
+
 1.4.4 - January 2, 2013
 =======================
 * Issue 94: The standalone version now has a CLI option to load default ZK/Exhibitor config

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/backup/s3/S3BackupProvider.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/backup/s3/S3BackupProvider.java
@@ -68,14 +68,26 @@ public class S3BackupProvider implements BackupProvider
     static final String       SEPARATOR = "/";
     private static final String       SEPARATOR_REPLACEMENT = "_";
 
-    public S3BackupProvider(S3ClientFactory factory, S3Credential credential) throws Exception
+    /**
+     * @param factory the factory
+     * @param credential credentials
+     * @param s3Region optional region or null
+     * @throws Exception errors
+     */
+    public S3BackupProvider(S3ClientFactory factory, S3Credential credential, String s3Region) throws Exception
     {
-        s3Client = factory.makeNewClient(credential);
+        s3Client = factory.makeNewClient(credential, s3Region);
     }
 
-    public S3BackupProvider(S3ClientFactory factory, S3CredentialsProvider credentialsProvider) throws Exception
+    /**
+     * @param factory the factory
+     * @param credentialsProvider credentials
+     * @param s3Region optional region or null
+     * @throws Exception errors
+     */
+    public S3BackupProvider(S3ClientFactory factory, S3CredentialsProvider credentialsProvider, String s3Region) throws Exception
     {
-        s3Client = factory.makeNewClient(credentialsProvider);
+        s3Client = factory.makeNewClient(credentialsProvider, s3Region);
     }
 
     public S3Client getS3Client()

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/s3/S3ConfigProvider.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/s3/S3ConfigProvider.java
@@ -39,25 +39,50 @@ public class S3ConfigProvider implements ConfigProvider
     private final String hostname;
     private final Properties defaults;
 
-    public S3ConfigProvider(S3ClientFactory factory, S3Credential credential, S3ConfigArguments arguments, String hostname) throws Exception
+    /**
+     * @param factory the factory
+     * @param credential credentials
+     * @param arguments args
+     * @param hostname this VM's hostname
+     * @param s3Region optional region or null
+     * @throws Exception errors
+     */
+    public S3ConfigProvider(S3ClientFactory factory, S3Credential credential, S3ConfigArguments arguments, String hostname, String s3Region) throws Exception
     {
-        this(factory, credential, arguments, hostname, new Properties());
+        this(factory, credential, arguments, hostname, new Properties(), s3Region);
     }
 
-    public S3ConfigProvider(S3ClientFactory factory, S3Credential credential, S3ConfigArguments arguments, String hostname, Properties defaults) throws Exception
+    /**
+     * @param factory the factory
+     * @param credential credentials
+     * @param arguments args
+     * @param hostname this VM's hostname
+     * @param defaults default props
+     * @param s3Region optional region or null
+     * @throws Exception errors
+     */
+    public S3ConfigProvider(S3ClientFactory factory, S3Credential credential, S3ConfigArguments arguments, String hostname, Properties defaults, String s3Region) throws Exception
     {
         this.arguments = arguments;
         this.hostname = hostname;
         this.defaults = defaults;
-        s3Client = factory.makeNewClient(credential);
+        s3Client = factory.makeNewClient(credential, s3Region);
     }
 
-    public S3ConfigProvider(S3ClientFactory factory, S3CredentialsProvider credentialsProvider, S3ConfigArguments arguments, String hostname, Properties defaults) throws Exception
+    /**
+     * @param factory the factory
+     * @param credentialsProvider credentials
+     * @param arguments args
+     * @param hostname this VM's hostname
+     * @param s3Region optional region or null
+     * @throws Exception errors
+     */
+    public S3ConfigProvider(S3ClientFactory factory, S3CredentialsProvider credentialsProvider, S3ConfigArguments arguments, String hostname, Properties defaults, String s3Region) throws Exception
     {
         this.arguments = arguments;
         this.hostname = hostname;
         this.defaults = defaults;
-        s3Client = factory.makeNewClient(credentialsProvider);
+        s3Client = factory.makeNewClient(credentialsProvider, s3Region);
     }
 
     public S3Client getS3Client()

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientFactory.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientFactory.java
@@ -21,22 +21,23 @@ public interface S3ClientFactory
     /**
      * Create a client with the given credentials
      *
-     *
      * @param credentials credentials
+     * @param s3Region the region to use or null
      * @return client
      * @throws Exception errors
      */
-    public S3Client makeNewClient(S3Credential credentials) throws Exception;
+    public S3Client makeNewClient(S3Credential credentials, String s3Region) throws Exception;
 
 
     /**
      * Create a client with the given credentials
      *
      * @param credentialsProvider credentials provider
+     * @param s3Region the region to use or null
      * @return client
      * @throws Exception errors
      */
-    public S3Client makeNewClient(S3CredentialsProvider credentialsProvider) throws Exception;
+    public S3Client makeNewClient(S3CredentialsProvider credentialsProvider, String s3Region) throws Exception;
 
 
 

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientFactoryImpl.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientFactoryImpl.java
@@ -16,24 +16,18 @@
 
 package com.netflix.exhibitor.core.s3;
 
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.*;
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
-
 public class S3ClientFactoryImpl implements S3ClientFactory
 {
     @Override
-    public S3Client makeNewClient(final S3Credential credentials) throws Exception
+    public S3Client makeNewClient(final S3Credential credentials, String s3Region) throws Exception
     {
-        return new S3ClientImpl(credentials);
+        return new S3ClientImpl(credentials, s3Region);
     }
 
     @Override
-    public S3Client makeNewClient(S3CredentialsProvider credentialsProvider) throws Exception
+    public S3Client makeNewClient(S3CredentialsProvider credentialsProvider, String s3Region) throws Exception
     {
-        return new S3ClientImpl(credentialsProvider);
+        return new S3ClientImpl(credentialsProvider, s3Region);
     }
 
 }

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/backup/s3/MockS3ClientFactory.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/backup/s3/MockS3ClientFactory.java
@@ -31,13 +31,13 @@ public class MockS3ClientFactory implements S3ClientFactory
     }
 
     @Override
-    public S3Client makeNewClient(S3Credential credentials) throws Exception
+    public S3Client makeNewClient(S3Credential credentials, String s3Region) throws Exception
     {
         return s3Client;
     }
 
     @Override
-    public S3Client makeNewClient(S3CredentialsProvider credentialsProvider) throws Exception {
+    public S3Client makeNewClient(S3CredentialsProvider credentialsProvider, String s3Region) throws Exception {
         return s3Client;
     }
 }

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/backup/s3/TestS3BackupProviderBase.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/backup/s3/TestS3BackupProviderBase.java
@@ -66,7 +66,7 @@ public abstract class TestS3BackupProviderBase
             MockS3Client        s3Client = new MockS3Client(null, null);
             s3Client.putObject(dummyRequest);
 
-            S3BackupProvider    provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()));
+            S3BackupProvider    provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()), null);
             out = new FileOutputStream(tempFile);
             provider.downloadBackup(null, new BackupMetaData("test", 1), out, Maps.<String, String>newHashMap());
             
@@ -105,7 +105,7 @@ public abstract class TestS3BackupProviderBase
         };
 
         MockS3Client            s3Client = new MockS3Client(null, listing);
-        S3BackupProvider        provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()));
+        S3BackupProvider        provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()), null);
         List<BackupMetaData>    backups = provider.getAvailableBackups(null, Maps.<String, String>newHashMap());
         List<String>            backupNames = Lists.transform
         (
@@ -125,7 +125,7 @@ public abstract class TestS3BackupProviderBase
     private byte[] getUploadedBytes(File sourceFile) throws Exception
     {
         MockS3Client        s3Client = new MockS3Client();
-        S3BackupProvider    provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()));
+        S3BackupProvider    provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()), null);
 
         provider.uploadBackup(null, new BackupMetaData("test", 10), sourceFile, Maps.<String, String>newHashMap());
 

--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCLI.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCLI.java
@@ -68,6 +68,7 @@ public class ExhibitorCLI
     public static final String S3_BACKUP = "s3backup";
     public static final String S3_CONFIG = "s3config";
     public static final String S3_CONFIG_PREFIX = "s3configprefix";
+    public static final String S3_REGION = "s3region";
     public static final String ZOOKEEPER_CONFIG_INITIAL_CONNECT_STRING = "zkconfigconnect";
     public static final String ZOOKEEPER_CONFIG_EXHIBITOR_PORT = "zkconfigexhibitorport";
     public static final String ZOOKEEPER_CONFIG_EXHIBITOR_URI_PATH = "zkconfigexhibitorpath";
@@ -142,6 +143,7 @@ public class ExhibitorCLI
 
         Options s3Options = new Options();
         s3Options.addOption(null, S3_CREDENTIALS, true, "Optional credentials to use for s3backup or s3config. Argument is the path to an AWS credential properties file with two properties: " + PropertyBasedS3Credential.PROPERTY_S3_KEY_ID + " and " + PropertyBasedS3Credential.PROPERTY_S3_SECRET_KEY);
+        s3Options.addOption(null, S3_REGION, true, "Optional region for S3 calls (e.g. \"eu-west-1\"). Will be used to set the S3 client's endpoint.");
 
         generalOptions = new Options();
         generalOptions.addOption(null, TIMEOUT, true, "Connection timeout (ms) for ZK connections. Default is 30000.");


### PR DESCRIPTION
Issue 103: S3 buckets outside of us-east-1 now require an "endpoint" to be set. For the standalone
version, use the new CLI --s3region <region>. e.g. "--s3region eu-west-1".
