### PR TITLE
fix for war creation

### DIFF
--- a/exhibitor-standalone/src/main/resources/buildscripts/war/maven/pom.xml
+++ b/exhibitor-standalone/src/main/resources/buildscripts/war/maven/pom.xml
@@ -25,19 +25,25 @@
                             <groupId>com.netflix.exhibitor</groupId>
                             <artifactId>exhibitor-standalone</artifactId>
                             <type>jar</type>
-                            <includes>WEB-INF/</includes>
+                            <includes>
+	                            <include>WEB-INF/</include>
+                            </includes>
                         </overlay>
 
                         <overlay>
                             <groupId>com.netflix.exhibitor</groupId>
                             <artifactId>exhibitor-standalone</artifactId>
                             <type>jar</type>
-                            <includes>com/</includes>
+                            <includes>
+	                            <include>com/</include>
+                            </includes>
                             <targetPath>WEB-INF/classes</targetPath>
                         </overlay>
 
                         <overlay>
-                            <includes>exhibitor.properties</includes>
+                            <includes>
+                            <include>exhibitor.properties</include>
+                            </includes>
                             <targetPath>WEB-INF/classes</targetPath>
                         </overlay>
                     </overlays>


### PR DESCRIPTION
Fix for the following error, due to syntax (according to maven docs) with using <includes> error.

Caused by: org.apache.maven.plugin.PluginConfigurationException: Unable to parse configuration of mojo org.apache.maven.plugins:maven-war-plugin:2.3:war for parameter includes: Cannot assign configuration entry 'includes' with value 'WEB-INF/' of type java.lang.String to property of type java.lang.String[]
    at org.apache.maven.plugin.internal.DefaultMavenPluginManager.populatePluginFields(DefaultMavenPluginManager.java:597)
    at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getConfiguredMojo(DefaultMavenPluginManager.java:529)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:92)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
    ... 19 more
