### PR TITLE
Check for configured index directory

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/index/IndexProcessorActivity.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/index/IndexProcessorActivity.java
@@ -39,16 +39,26 @@ public class IndexProcessorActivity implements Activity
     @Override
     public Boolean call() throws Exception
     {
-        try
+        String path = exhibitor.getConfigManager().getConfig().getString(StringConfigs.LOG_INDEX_DIRECTORY);
+
+        if ( path == null )
         {
-            File            indexDirectory = new File(exhibitor.getConfigManager().getConfig().getString(StringConfigs.LOG_INDEX_DIRECTORY), "exhibitor-" + System.currentTimeMillis());
-            IndexProcessor  processor = new IndexProcessor(exhibitor);
-            processor.process(indexDirectory);
+            exhibitor.getLog().add(ActivityLog.Type.ERROR, "No index directory set in config");
         }
-        catch ( Exception e )
+        else
         {
-            exhibitor.getLog().add(ActivityLog.Type.ERROR, "Building Index", e);
+            try
+            {
+                File            indexDirectory = new File(path, "exhibitor-" + System.currentTimeMillis());
+                IndexProcessor  processor = new IndexProcessor(exhibitor);
+                processor.process(indexDirectory);
+            }
+            catch ( Exception e )
+            {
+                exhibitor.getLog().add(ActivityLog.Type.ERROR, "Building Index", e);
+            }
         }
+
         return null;
     }
 }


### PR DESCRIPTION
Before attempting to write an index first check to see if the
directory configuration exists. This corrects the current behavior
of attempting to write to a path such as '/exhibitor-XXX' which
unless exhibitor is being run as root will not be able to write to.
