### PR TITLE
1) Default properties were not getting set correctly causing a brand new...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+1.5.1 - xxxxxxxxxxxxx
+=====================
+* Default properties were not getting set correctly causing a brand new install of Exhibitor
+to have no defaults set. This could be the cause of Issue 148.
+
+* ZookeeperConfigProvider wasn't creating parent paths.
+
 1.5.0 - July 29, 2013
 =====================
 * Switching to correct semantic versioning.

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/zookeeper/ZookeeperConfigProvider.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/zookeeper/ZookeeperConfigProvider.java
@@ -130,7 +130,7 @@ public class ZookeeperConfigProvider implements ConfigProvider
         {
             try
             {
-                client.create().forPath(ZKPaths.makePath(configPath, CONFIG_NODE_NAME), bytes);
+                client.create().creatingParentsIfNeeded().forPath(ZKPaths.makePath(configPath, CONFIG_NODE_NAME), bytes);
                 newVersion = 0;
             }
             catch ( KeeperException.NodeExistsException e1 )

--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCreator.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCreator.java
@@ -342,7 +342,9 @@ public class ExhibitorCreator
             }
         }
 
-        return new PropertyBasedInstanceConfig(fixedDefaultProperties, DefaultProperties.get(backupProvider)).getProperties();
+        Properties properties = new PropertyBasedInstanceConfig(fixedDefaultProperties, new Properties()).getProperties();
+        properties.putAll(DefaultProperties.get(backupProvider));
+        return properties;
     }
 
     private ConfigProvider getNoneProvider(CommandLine commandLine, Properties defaultProperties)


### PR DESCRIPTION
... install of Exhibitor

to have no defaults set. This could be the cause of Issue 148.

2) ZookeeperConfigProvider wasn't creating parent paths.
