### PR TITLE
GenerateHostname is necessary in EC2 environment with IP address server list configuration

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/rest/ClusterResource.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/rest/ClusterResource.java
@@ -60,7 +60,7 @@ public class ClusterResource
     public ClusterResource(@Context ContextResolver<UIContext> resolver)
     {
         context = resolver.getContext(UIContext.class);
-        genHostname = new GenerateHostname();
+        genHostname = new GenerateHostname(System.getenv("EC2_PUBLIC_HOSTNAME"));
     }
 
     @Path("status")

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/rest/GenerateHostname.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/rest/GenerateHostname.java
@@ -3,8 +3,7 @@ package com.netflix.exhibitor.core.rest;
 public class GenerateHostname {
     private final String suffix;
 
-    public GenerateHostname() {
-        String hostname = System.getenv("EC2_PUBLIC_HOSTNAME");
+    public GenerateHostname(String hostname) {
         if (hostname != null) {
             suffix = hostname.substring(hostname.indexOf('.'));
         } else {

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/rest/TestGenerateHostname.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/rest/TestGenerateHostname.java
@@ -7,10 +7,21 @@ import static org.testng.Assert.assertEquals;
 public class TestGenerateHostname {
     @Test
     public void test() {
-        GenerateHostname gen = new GenerateHostname();
+        GenerateHostname gen = new GenerateHostname("ec2-127-0-0-1.eu-west-1.compute.amazonaws.com");
         assertEquals(
                 gen.getHostname("127.0.0.1"),
                 "ec2-127-0-0-1.eu-west-1.compute.amazonaws.com");
+        assertEquals(
+                gen.getHostname("ec2-127-0-0-1.eu-west-1.compute.amazonaws.com"),
+                "ec2-127-0-0-1.eu-west-1.compute.amazonaws.com");
+    }
+
+    @Test
+    public void testNull() {
+        GenerateHostname gen = new GenerateHostname(null);
+        assertEquals(
+                gen.getHostname("127.0.0.1"),
+                "127.0.0.1");
         assertEquals(
                 gen.getHostname("ec2-127-0-0-1.eu-west-1.compute.amazonaws.com"),
                 "ec2-127-0-0-1.eu-west-1.compute.amazonaws.com");


### PR DESCRIPTION
When we want to setup zoo.cfg in EC2 environment, ExhibitorEnsembleProvider should return server list as public hostname, not IP address because communicating with IP address is not allowed in EC2 environment. So, we need to change IP address to public hostname in cluster/list REST api.
