### PR TITLE
Manual Restart & Rolling Config Release bug fixed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,9 @@ project(':exhibitor-core') {
             // JLine pulls this in as a compile dependency, they have fixed it in future versions
             exclude group: 'junit', module: 'junit'
         }
-        compile 'org.apache.curator:curator-framework:2.2.0-incubating'
-        compile 'org.apache.curator:curator-recipes:2.2.0-incubating'
-        compile 'com.netflix.servo:servo-core:0.4.20'
+        compile 'org.apache.curator:curator-framework:2.3.0'
+        compile 'org.apache.curator:curator-recipes:2.3.0'
+        compile 'com.netflix.servo:servo-core:0.5.2'
         compile 'com.google.guava:guava:11.0.1'
         compile 'javax.ws.rs:jsr311-api:1.1.1'
         compile 'org.codehaus.jackson:jackson-mapper-asl:1.8.3'
@@ -61,7 +61,7 @@ project(':exhibitor-core') {
         compile 'com.sun.jersey:jersey-bundle:1.9.1'  // should be provided - gradle doesn't support
         compile 'com.sun.xml.bind:jaxb-impl:2.2.4'   // should be provided - gradle doesn't support
 
-        testCompile 'org.apache.curator:curator-test:2.2.0-incubating'
+        testCompile 'org.apache.curator:curator-test:2.3.0'
         testCompile 'org.mortbay.jetty:jetty:6.1.22'
         testCompile 'org.mockito:mockito-core:1.8.5'
     }

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/ConfigManager.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/ConfigManager.java
@@ -151,6 +151,31 @@ public class ConfigManager implements Closeable
         }
     }
 
+    public synchronized boolean isRollingMe(InstanceState instanceState) {
+        ConfigCollection localConfig = getCollection();
+        if ( localConfig.isRolling() )
+        {
+            RollingReleaseState     state = new RollingReleaseState(instanceState, localConfig);
+            if ( state.getCurrentRollingHostname().equals(exhibitor.getThisJVMHostname()) )
+            {
+                if ( state.serverListHasSynced() )
+                {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else
+        {
+            return true;
+        }
+    }
+
     public synchronized void     checkRollingConfig(InstanceState instanceState) throws Exception
     {
         ConfigCollection localConfig = getCollection();

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/DefaultProperties.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/DefaultProperties.java
@@ -158,7 +158,6 @@ public class DefaultProperties
                     {
                         return 1;
                     }
-
                 }
                 return 0;
             }

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/IntConfigs.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/IntConfigs.java
@@ -176,6 +176,18 @@ public enum IntConfigs
         {
             return false;
         }
+    },
+
+    /**
+     * boolean - if true (non zero) instance is restarted automatically on RestartSignificantConfig changes
+     */
+    MANUAL_RESTART()
+    {
+        @Override
+        public boolean isRestartSignificant()
+        {
+            return false;
+        }
     }
     ;
 

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/StandardProcessOperations.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/StandardProcessOperations.java
@@ -93,22 +93,7 @@ public class StandardProcessOperations implements ProcessOperations
     @Override
     public void startInstance() throws Exception
     {
-        Details         details = new Details(exhibitor);
-        String          javaEnvironmentScript = exhibitor.getConfigManager().getConfig().getString(StringConfigs.JAVA_ENVIRONMENT);
-        String          log4jProperties = exhibitor.getConfigManager().getConfig().getString(StringConfigs.LOG4J_PROPERTIES);
-
-        prepConfigFile(details);
-        if ( (javaEnvironmentScript != null) && (javaEnvironmentScript.trim().length() > 0) )
-        {
-            File     envFile = new File(details.configDirectory, "java.env");
-            Files.write(javaEnvironmentScript, envFile, Charset.defaultCharset());
-        }
-
-        if ( (log4jProperties != null) && (log4jProperties.trim().length() > 0) )
-        {
-            File     log4jFile = new File(details.configDirectory, "log4j.properties");
-            Files.write(log4jProperties, log4jFile, Charset.defaultCharset());
-        }
+        Details details = writeConfigFiles();
 
         File            binDirectory = new File(details.zooKeeperDirectory, "bin");
         File            startScript = new File(binDirectory, "zkServer.sh");
@@ -117,6 +102,26 @@ public class StandardProcessOperations implements ProcessOperations
         exhibitor.getProcessMonitor().monitor(ProcessTypes.ZOOKEEPER, builder.start(), null, ProcessMonitor.Mode.LEAVE_RUNNING_ON_INTERRUPT, ProcessMonitor.Streams.BOTH);
 
         exhibitor.getLog().add(ActivityLog.Type.INFO, "Process started via: " + startScript.getPath());
+    }
+
+    public Details writeConfigFiles() throws IOException {
+        Details         details = new Details(exhibitor);
+        String          javaEnvironmentScript = exhibitor.getConfigManager().getConfig().getString(StringConfigs.JAVA_ENVIRONMENT);
+        String          log4jProperties = exhibitor.getConfigManager().getConfig().getString(StringConfigs.LOG4J_PROPERTIES);
+
+        prepConfigFile(details);
+        if ( (javaEnvironmentScript != null) && (javaEnvironmentScript.trim().length() > 0) )
+        {
+            File envFile = new File(details.configDirectory, "java.env");
+            Files.write(javaEnvironmentScript, envFile, Charset.defaultCharset());
+        }
+
+        if ( (log4jProperties != null) && (log4jProperties.trim().length() > 0) )
+        {
+            File     log4jFile = new File(details.configDirectory, "log4j.properties");
+            Files.write(log4jProperties, log4jFile, Charset.defaultCharset());
+        }
+        return details;
     }
 
     private void prepConfigFile(Details details) throws IOException

--- a/exhibitor-core/src/main/resources/com/netflix/exhibitor/core/ui/index.html
+++ b/exhibitor-core/src/main/resources/com/netflix/exhibitor/core/ui/index.html
@@ -209,6 +209,10 @@
                         <label for="config-check-ms">Live Check (ms)</label><input type="text" id="config-check-ms" class="mask-pint" name="config-check-ms" size="8" title="The number of milliseconds between live-ness checks on the ZooKeeper server"><br clear="all"/>
                         <label for="config-cleanup-ms">Cleanup Period (ms)</label><input type="text" id="config-cleanup-ms" class="mask-pint" name="config-cleanup-ms" size="8" title="The number of milliseconds between ZooKeeper log file cleanups"><br clear="all"/>
                         <label for="config-cleanup-max-files">Cleanup: Max Log Files</label><input type="text" id="config-cleanup-max-files" class="mask-pint" name="config-cleanup-max-files" size="2" title="The max number of ZooKeeper log files to keep when cleaning up"><br clear="all"/>
+                        <label for="config-manual-restart">Manual Restart on Config Change</label><select id="config-manual-restart" class="mask-pint" name="config-manual-restart" size="1" title="If set to 'yes', on any config change release, exhibitor won't restart zookeeper.">
+                            <option value="0">No</option>
+                            <option value="1">Yes</option>
+                        </select><br clear="all"/>
                     </fieldset>
 
                     <fieldset id="config-backups-fieldset">

--- a/exhibitor-core/src/main/resources/com/netflix/exhibitor/core/ui/js/exhibitor.js
+++ b/exhibitor-core/src/main/resources/com/netflix/exhibitor/core/ui/js/exhibitor.js
@@ -253,6 +253,7 @@ function buildNewConfig()
     newConfig.autoManageInstancesSettlingPeriodMs = $('#config-automatic-management-period-ms').val();
     newConfig.autoManageInstancesFixedEnsembleSize = $('#config-fixed-ensemble-size').val();
     newConfig.autoManageInstancesApplyAllAtOnce = $('#config-apply-all-at-once').val();
+    newConfig.manualRestart = $('#config-manual-restart').val();
     newConfig.observerThreshold = $('#config-observer-threshold').val();
     newConfig.serversSpec = $('#config-servers-spec').val();
     newConfig.javaEnvironment = $('#config-java-env').val();
@@ -363,6 +364,7 @@ function ableConfig(enable)
     $('#config-fixed-ensemble-size').prop('disabled', !enable);
     $('#config-observer-threshold').prop('disabled', !enable);
     $('#config-apply-all-at-once').prop('disabled', !enable);
+    $('#config-manual-restart').prop('disabled', !enable);
     $('#config-log-index-dir').prop('disabled', !enable);
     $('#config-servers-spec').prop('disabled', !enable);
     $('#config-java-env').prop('disabled', !enable);
@@ -407,6 +409,7 @@ function updateConfig()
     $('#config-fixed-ensemble-size').val(systemConfig.autoManageInstancesFixedEnsembleSize);
     $('#config-observer-threshold').val(systemConfig.observerThreshold);
     $('#config-apply-all-at-once').val(systemConfig.autoManageInstancesApplyAllAtOnce);
+    $('#config-manual-restart').val(systemConfig.manualRestart);
     $('#config-log-index-dir').val(systemConfig.logIndexDirectory);
     $('#config-servers-spec').val(systemConfig.serversSpec);
     $('#config-java-env').val(systemConfig.javaEnvironment);


### PR DESCRIPTION
- manual-restart configuration is added in UI and IntConfigs

If this is true, on any configuration change, exhibitor does not restart zookeeper
- In MonitorRunningInstance, when exhibitor should restart zookeeper such as configuration change or server list change, it just schedule restarting zookeeper. When the current rolling host name is itself(implemented on ConfigManager.isRollingMe) and restarting zookeeper is scheduled, exhibitor actually restart the zookeeper. When manual-restart is true, restarting the zookeeper wouldn't be scheduled
- curator version is updated to 2.3.0
- servo-core version is updated to 0.5.2
