### PR TITLE
Configuration Rolling Release bug fixed

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/ConfigManager.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/ConfigManager.java
@@ -151,6 +151,31 @@ public class ConfigManager implements Closeable
         }
     }
 
+    public synchronized boolean isRollingMe(InstanceState instanceState) {
+        ConfigCollection localConfig = getCollection();
+        if ( localConfig.isRolling() )
+        {
+            RollingReleaseState     state = new RollingReleaseState(instanceState, localConfig);
+            if ( state.getCurrentRollingHostname().equals(exhibitor.getThisJVMHostname()) )
+            {
+                if ( state.serverListHasSynced() )
+                {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else
+        {
+            return true;
+        }
+    }
+
     public synchronized void     checkRollingConfig(InstanceState instanceState) throws Exception
     {
         ConfigCollection localConfig = getCollection();


### PR DESCRIPTION
About the bug description, please refer to https://github.com/Netflix/exhibitor/issues/166

In MonitorRunningInstance, when exhibitor should restart zookeeper such as configuration change or server list change, it just schedules restarting zookeeper. When the current rolling host name is itself(implemented on ConfigManager.isRollingMe) and restarting zookeeper is scheduled, exhibitor actually restart the zookeeper.

When restarting is not scheduled but RestartSignificantConfigucation is changed, it should write the new configuration file. StandardProcessOperation.writeConfigFile method is created so.
