### PR TITLE
Monitor stdout when cleaning logs

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/StandardProcessOperations.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/StandardProcessOperations.java
@@ -69,7 +69,7 @@ public class StandardProcessOperations implements ProcessOperations
             Integer.toString(exhibitor.getConfigManager().getConfig().getInt(IntConfigs.CLEANUP_MAX_FILES))
         );
 
-        exhibitor.getProcessMonitor().monitor(ProcessTypes.CLEANUP, builder.start(), "Cleanup task completed", ProcessMonitor.Mode.DESTROY_ON_INTERRUPT, ProcessMonitor.Streams.ERROR);
+        exhibitor.getProcessMonitor().monitor(ProcessTypes.CLEANUP, builder.start(), "Cleanup task completed", ProcessMonitor.Mode.DESTROY_ON_INTERRUPT, ProcessMonitor.Streams.BOTH);
     }
 
     @Override


### PR DESCRIPTION
Read from both stdout and stderr when forking `org.apache.zookeeper.server.PurgeTxnLog`. This ensures the stdout pipe does not get filled up and the purge can complete successfully.

Closes #179.
