### PR TITLE
handle null bytes from getData request

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/rest/ExplorerResource.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/rest/ExplorerResource.java
@@ -198,10 +198,13 @@ public class ExplorerResource
             Stat stat = context.getExhibitor().getLocalConnection().checkExists().forPath(key);
             byte[]          bytes = context.getExhibitor().getLocalConnection().getData().storingStatIn(stat).forPath(key);
 
-            String          bytesStr = bytesToString(bytes);
-
-            node.put("bytes", bytesStr);
-            node.put("str", new String(bytes, "UTF-8"));
+            if (bytes != null) {
+                node.put("bytes", bytesToString(bytes));
+                node.put("str", new String(bytes, "UTF-8"));
+            } else {
+                node.put("bytes", "");
+                node.put("str", "");
+            }
             node.put("stat", reflectToString(stat));
         }
         catch ( KeeperException.NoNodeException dummy )


### PR DESCRIPTION
It seems pretty legit for zookeeper `getData` to return null as data bytes. Exhibitor should handle this case. Otherwise user sees `Exception` as node data.
Tested manually on local installation.
