### PR TITLE
Pad data bytes to two characters

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/rest/ExplorerResource.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/rest/ExplorerResource.java
@@ -72,7 +72,8 @@ public class ExplorerResource
         StringBuilder       bytesStr = new StringBuilder();
         for ( byte b : bytes )
         {
-            bytesStr.append(Integer.toHexString(b & 0xff)).append(" ");
+            String byteAsStr = String.format("%02x", (0xFF & b));
+            bytesStr.append(byteAsStr).append(" ");
         }
         return bytesStr.toString();
     }


### PR DESCRIPTION
The Exhibitor UI (specifically fromBinary() in exhibitor-modify.js)
depends on two character hex strings.

This fixes issue #185
