### PR TITLE
Adding optional proxy configuration for AmazonS3Client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ project(':exhibitor-core') {
         // if you are using Java 7 you can remove this and switch to the JDK version
         compile 'org.codehaus.jsr166-mirror:jsr166y:1.7.0'
 
-        compile 'com.amazonaws:aws-java-sdk:1.3.22'   // should be provided - gradle doesn't support
+        compile 'com.amazonaws:aws-java-sdk:1.9.3'   // should be provided - gradle doesn't support
         compile 'com.sun.jersey:jersey-bundle:1.9.1'  // should be provided - gradle doesn't support
         compile 'com.sun.xml.bind:jaxb-impl:2.2.4'   // should be provided - gradle doesn't support
 
@@ -87,7 +87,7 @@ project(':exhibitor-standalone') {
         compile 'org.mortbay.jetty:jetty:6.1.22'
         compile 'com.google.guava:guava:11.0.1'
         compile 'commons-cli:commons-cli:1.2'
-        compile 'com.amazonaws:aws-java-sdk:1.3.22'
+        compile 'com.amazonaws:aws-java-sdk:1.9.3'
         compile 'org.slf4j:slf4j-log4j12:1.7.0'
     }
 }

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/backup/s3/S3BackupProvider.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/backup/s3/S3BackupProvider.java
@@ -35,6 +35,7 @@ import com.netflix.exhibitor.core.s3.S3Client;
 import com.netflix.exhibitor.core.s3.S3ClientFactory;
 import com.netflix.exhibitor.core.s3.S3Credential;
 import com.netflix.exhibitor.core.s3.S3CredentialsProvider;
+import com.netflix.exhibitor.core.s3.S3ClientConfig;
 import com.netflix.exhibitor.core.s3.S3Utils;
 import org.apache.curator.RetryLoop;
 import org.apache.curator.RetryPolicy;
@@ -91,6 +92,30 @@ public class S3BackupProvider implements BackupProvider
     public S3BackupProvider(S3ClientFactory factory, S3CredentialsProvider credentialsProvider, String s3Region) throws Exception
     {
         s3Client = factory.makeNewClient(credentialsProvider, s3Region);
+    }
+
+    /**
+     * @param factory the factory
+     * @param credential credentials
+     * @param clientConfig s3 client configuration
+     * @param s3Region optional region or null
+     * @throws Exception errors
+     */
+    public S3BackupProvider(S3ClientFactory factory, S3Credential credential, S3ClientConfig clientConfig, String s3Region) throws Exception
+    {
+        s3Client = factory.makeNewClient(credential, clientConfig, s3Region);
+    }
+
+    /**
+     * @param factory the factory
+     * @param credentialsProvider credentials
+     * @param clientConfig s3 client configuration
+     * @param s3Region optional region or null
+     * @throws Exception errors
+     */
+    public S3BackupProvider(S3ClientFactory factory, S3CredentialsProvider credentialsProvider, S3ClientConfig clientConfig, String s3Region) throws Exception
+    {
+        s3Client = factory.makeNewClient(credentialsProvider, clientConfig, s3Region);
     }
 
     public S3Client getS3Client()

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/s3/S3ConfigProvider.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/config/s3/S3ConfigProvider.java
@@ -85,6 +85,55 @@ public class S3ConfigProvider implements ConfigProvider
         s3Client = factory.makeNewClient(credentialsProvider, s3Region);
     }
 
+    /**
+     * @param factory the factory
+     * @param credential credentials
+     * @param clientConfig s3 client configuration
+     * @param arguments args
+     * @param hostname this VM's hostname
+     * @param s3Region optional region or null
+     * @throws Exception errors
+     */
+    public S3ConfigProvider(S3ClientFactory factory, S3Credential credential, S3ClientConfig clientConfig, S3ConfigArguments arguments, String hostname, String s3Region) throws Exception
+    {
+        this(factory, credential, clientConfig, arguments, hostname, new Properties(), s3Region);
+    }
+
+    /**
+     * @param factory the factory
+     * @param credential credentials
+     * @param clientConfig s3 client configuration
+     * @param arguments args
+     * @param hostname this VM's hostname
+     * @param defaults default props
+     * @param s3Region optional region or null
+     * @throws Exception errors
+     */
+    public S3ConfigProvider(S3ClientFactory factory, S3Credential credential, S3ClientConfig clientConfig, S3ConfigArguments arguments, String hostname, Properties defaults, String s3Region) throws Exception
+    {
+        this.arguments = arguments;
+        this.hostname = hostname;
+        this.defaults = defaults;
+        s3Client = factory.makeNewClient(credential, clientConfig, s3Region);
+    }
+
+    /**
+     * @param factory the factory
+     * @param credentialsProvider credentials
+     * @param clientConfig s3 client configuration
+     * @param arguments args
+     * @param hostname this VM's hostname
+     * @param s3Region optional region or null
+     * @throws Exception errors
+     */
+    public S3ConfigProvider(S3ClientFactory factory, S3CredentialsProvider credentialsProvider, S3ClientConfig clientConfig, S3ConfigArguments arguments, String hostname, Properties defaults, String s3Region) throws Exception
+    {
+        this.arguments = arguments;
+        this.hostname = hostname;
+        this.defaults = defaults;
+        s3Client = factory.makeNewClient(credentialsProvider, clientConfig, s3Region);
+    }
+
     public S3Client getS3Client()
     {
         return s3Client;

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/PropertyBasedS3ClientConfig.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/PropertyBasedS3ClientConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012 Netflix, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.netflix.exhibitor.core.s3;
+
+import com.google.common.io.Closeables;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import com.amazonaws.ClientConfiguration;
+
+public class PropertyBasedS3ClientConfig implements S3ClientConfig
+{
+    private final String proxyHost;
+    private final int proxyPort;
+    private final String proxyUsername;
+    private final String proxyPassword;
+
+    public static final String PROPERTY_S3_PROXY_HOST = "com.netflix.exhibitor.s3.proxy-host";
+    public static final String PROPERTY_S3_PROXY_PORT = "com.netflix.exhibitor.s3.proxy-port";
+    public static final String PROPERTY_S3_PROXY_USERNAME = "com.netflix.exhibitor.s3.proxy-username";
+    public static final String PROPERTY_S3_PROXY_PASSWORD = "com.netflix.exhibitor.s3.proxy-password";
+
+    public PropertyBasedS3ClientConfig(File propertiesFile) throws IOException
+    {
+        this(loadProperties(propertiesFile));
+    }
+
+    public PropertyBasedS3ClientConfig(Properties properties)
+    {
+        proxyHost = properties.getProperty(PROPERTY_S3_PROXY_HOST);
+        proxyPort = Integer.parseInt(properties.getProperty(PROPERTY_S3_PROXY_PORT));
+        proxyUsername = properties.getProperty(PROPERTY_S3_PROXY_USERNAME);
+        proxyPassword = properties.getProperty(PROPERTY_S3_PROXY_PASSWORD);
+    }
+
+    @Override
+    public ClientConfiguration getAWSClientConfig()
+    {
+        ClientConfiguration awsClientConfig = new ClientConfiguration();
+        awsClientConfig.setProxyHost(proxyHost);
+        awsClientConfig.setProxyPort(proxyPort);
+
+        if ( proxyUsername != null )
+        {
+            awsClientConfig.setProxyUsername(proxyUsername);
+        }
+
+        if ( proxyPassword != null )
+        {
+            awsClientConfig.setProxyPassword(proxyPassword);
+        }
+        return awsClientConfig;
+    }
+
+    private static Properties loadProperties(File propertiesFile) throws IOException
+    {
+        Properties      properties = new Properties();
+        InputStream     in = new BufferedInputStream(new FileInputStream(propertiesFile));
+        try
+        {
+            properties.load(in);
+        }
+        finally
+        {
+            Closeables.closeQuietly(in);
+        }
+        return properties;
+    }
+}

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3Client.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3Client.java
@@ -23,6 +23,8 @@ public interface S3Client extends Closeable
 {
     public void changeCredentials(S3Credential credential) throws Exception;
 
+    public void changeCredentials(S3Credential credential, S3ClientConfig clientConfig) throws Exception;
+
     public InitiateMultipartUploadResult initiateMultipartUpload(InitiateMultipartUploadRequest request) throws Exception;
 
     public S3Object getObject(String bucket, String key) throws Exception;

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientConfig.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012 Netflix, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.netflix.exhibitor.core.s3;
+
+import com.amazonaws.ClientConfiguration;
+
+public interface S3ClientConfig
+{
+    public ClientConfiguration getAWSClientConfig();
+}

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientFactory.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientFactory.java
@@ -39,6 +39,27 @@ public interface S3ClientFactory
      */
     public S3Client makeNewClient(S3CredentialsProvider credentialsProvider, String s3Region) throws Exception;
 
+    /**
+     * Create a client with the given credentials
+     *
+     * @param credentials credentials
+     * @param clientConfig s3 client configuration
+     * @param s3Region the region to use or null
+     * @return client
+     * @throws Exception errors
+     */
+    public S3Client makeNewClient(S3Credential credentials, S3ClientConfig clientConfig, String s3Region) throws Exception;
 
+
+    /**
+     * Create a client with the given credentials
+     *
+     * @param credentialsProvider credentials provider
+     * @param clientConfig s3 client configuration
+     * @param s3Region the region to use or null
+     * @return client
+     * @throws Exception errors
+     */
+    public S3Client makeNewClient(S3CredentialsProvider credentialsProvider, S3ClientConfig clientConfig, String s3Region) throws Exception;
 
 }

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientFactoryImpl.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientFactoryImpl.java
@@ -25,9 +25,21 @@ public class S3ClientFactoryImpl implements S3ClientFactory
     }
 
     @Override
+    public S3Client makeNewClient(final S3Credential credentials, final S3ClientConfig clientConfig, String s3Region) throws Exception
+    {
+        return new S3ClientImpl(credentials, clientConfig, s3Region);
+    }
+
+    @Override
     public S3Client makeNewClient(S3CredentialsProvider credentialsProvider, String s3Region) throws Exception
     {
         return new S3ClientImpl(credentialsProvider, s3Region);
+    }
+
+    @Override
+    public S3Client makeNewClient(S3CredentialsProvider credentialsProvider, final S3ClientConfig clientConfig, String s3Region) throws Exception
+    {
+        return new S3ClientImpl(credentialsProvider, clientConfig, s3Region);
     }
 
 }

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/backup/s3/MockS3Client.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/backup/s3/MockS3Client.java
@@ -23,6 +23,7 @@ import com.google.common.io.ByteStreams;
 import com.netflix.exhibitor.core.s3.S3Client;
 import com.netflix.exhibitor.core.s3.S3Credential;
 import com.netflix.exhibitor.core.s3.S3Utils;
+import com.netflix.exhibitor.core.s3.S3ClientConfig;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -55,9 +56,14 @@ public class MockS3Client implements S3Client
         }
         this.listing = listing;
     }
-
     @Override
     public void changeCredentials(S3Credential credential) throws Exception
+    {
+        // NOP
+    }
+
+    @Override
+    public void changeCredentials(S3Credential credential, S3ClientConfig clientConfig) throws Exception
     {
         // NOP
     }

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/backup/s3/MockS3ClientFactory.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/backup/s3/MockS3ClientFactory.java
@@ -20,6 +20,7 @@ import com.netflix.exhibitor.core.s3.S3Client;
 import com.netflix.exhibitor.core.s3.S3ClientFactory;
 import com.netflix.exhibitor.core.s3.S3Credential;
 import com.netflix.exhibitor.core.s3.S3CredentialsProvider;
+import com.netflix.exhibitor.core.s3.S3ClientConfig;
 
 public class MockS3ClientFactory implements S3ClientFactory
 {
@@ -37,7 +38,18 @@ public class MockS3ClientFactory implements S3ClientFactory
     }
 
     @Override
+    public S3Client makeNewClient(S3Credential credentials, S3ClientConfig clientConfig, String s3Region) throws Exception
+    {
+        return s3Client;
+    }
+
+    @Override
     public S3Client makeNewClient(S3CredentialsProvider credentialsProvider, String s3Region) throws Exception {
+        return s3Client;
+    }
+
+    @Override
+    public S3Client makeNewClient(S3CredentialsProvider credentialsProvider, S3ClientConfig clientConfig, String s3Region) throws Exception {
         return s3Client;
     }
 }

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/backup/s3/TestS3BackupProviderBase.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/backup/s3/TestS3BackupProviderBase.java
@@ -24,6 +24,7 @@ import com.google.common.io.Closeables;
 import com.google.common.io.Files;
 import com.netflix.exhibitor.core.backup.BackupMetaData;
 import com.netflix.exhibitor.core.s3.PropertyBasedS3Credential;
+import com.netflix.exhibitor.core.s3.PropertyBasedS3ClientConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -66,7 +67,7 @@ public abstract class TestS3BackupProviderBase
             MockS3Client        s3Client = new MockS3Client(null, null);
             s3Client.putObject(dummyRequest);
 
-            S3BackupProvider    provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()), null);
+            S3BackupProvider    provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()), new PropertyBasedS3ClientConfig(new Properties()), null);
             out = new FileOutputStream(tempFile);
             provider.downloadBackup(null, new BackupMetaData("test", 1), out, Maps.<String, String>newHashMap());
             
@@ -105,7 +106,7 @@ public abstract class TestS3BackupProviderBase
         };
 
         MockS3Client            s3Client = new MockS3Client(null, listing);
-        S3BackupProvider        provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()), null);
+        S3BackupProvider        provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()), new PropertyBasedS3ClientConfig(new Properties()), null);
         List<BackupMetaData>    backups = provider.getAvailableBackups(null, Maps.<String, String>newHashMap());
         List<String>            backupNames = Lists.transform
         (
@@ -125,7 +126,7 @@ public abstract class TestS3BackupProviderBase
     private byte[] getUploadedBytes(File sourceFile) throws Exception
     {
         MockS3Client        s3Client = new MockS3Client();
-        S3BackupProvider    provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()), null);
+        S3BackupProvider    provider = new S3BackupProvider(new MockS3ClientFactory(s3Client), new PropertyBasedS3Credential(new Properties()), new PropertyBasedS3ClientConfig(new Properties()), null);
 
         provider.uploadBackup(null, new BackupMetaData("test", 10), sourceFile, Maps.<String, String>newHashMap());
 

--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCLI.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCLI.java
@@ -26,6 +26,7 @@ import com.netflix.exhibitor.core.config.JQueryStyle;
 import com.netflix.exhibitor.core.config.PropertyBasedInstanceConfig;
 import com.netflix.exhibitor.core.config.StringConfigs;
 import com.netflix.exhibitor.core.s3.PropertyBasedS3Credential;
+import com.netflix.exhibitor.core.s3.PropertyBasedS3ClientConfig;
 import com.netflix.exhibitor.core.state.ManifestVersion;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
@@ -65,6 +66,7 @@ public class ExhibitorCLI
     public static final String FILESYSTEM_CONFIG_NAME = "fsconfigname";
     public static final String FILESYSTEM_CONFIG_LOCK_PREFIX = "fsconfiglockprefix";
     public static final String S3_CREDENTIALS = "s3credentials";
+    public static final String S3_PROXY = "s3proxy";
     public static final String S3_BACKUP = "s3backup";
     public static final String S3_CONFIG = "s3config";
     public static final String S3_CONFIG_PREFIX = "s3configprefix";
@@ -154,6 +156,7 @@ public class ExhibitorCLI
         Options s3Options = new Options();
         s3Options.addOption(null, S3_CREDENTIALS, true, "Optional credentials to use for s3backup or s3config. Argument is the path to an AWS credential properties file with two properties: " + PropertyBasedS3Credential.PROPERTY_S3_KEY_ID + " and " + PropertyBasedS3Credential.PROPERTY_S3_SECRET_KEY);
         s3Options.addOption(null, S3_REGION, true, "Optional region for S3 calls (e.g. \"eu-west-1\"). Will be used to set the S3 client's endpoint.");
+        s3Options.addOption(null, S3_PROXY, true, "Optional configuration used when when connecting to S3 via a proxy. Argument is the path to an AWS credential properties file with four properties (only host, port and protocol are required if using a proxy): " + PropertyBasedS3ClientConfig.PROPERTY_S3_PROXY_HOST + ", " + PropertyBasedS3ClientConfig.PROPERTY_S3_PROXY_PORT + ", " + PropertyBasedS3ClientConfig.PROPERTY_S3_PROXY_USERNAME + ", " + PropertyBasedS3ClientConfig.PROPERTY_S3_PROXY_PASSWORD);
 
         generalOptions = new Options();
         generalOptions.addOption(null, TIMEOUT, true, "Connection timeout (ms) for ZK connections. Default is 30000.");

--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCreator.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCreator.java
@@ -38,6 +38,7 @@ import com.netflix.exhibitor.core.config.s3.S3ConfigAutoManageLockArguments;
 import com.netflix.exhibitor.core.config.s3.S3ConfigProvider;
 import com.netflix.exhibitor.core.config.zookeeper.ZookeeperConfigProvider;
 import com.netflix.exhibitor.core.s3.PropertyBasedS3Credential;
+import com.netflix.exhibitor.core.s3.PropertyBasedS3ClientConfig;
 import com.netflix.exhibitor.core.s3.S3ClientFactoryImpl;
 import com.netflix.exhibitor.core.servo.ServoRegistration;
 import com.netflix.servo.jmx.JmxMonitorRegistry;
@@ -117,17 +118,23 @@ public class ExhibitorCreator
 
         checkMutuallyExclusive(cli, commandLine, S3_BACKUP, FILESYSTEMBACKUP);
 
-        String                      s3Region = commandLine.getOptionValue(S3_REGION, null);
-        PropertyBasedS3Credential   awsCredentials = null;
+        String                        s3Region = commandLine.getOptionValue(S3_REGION, null);
+        PropertyBasedS3Credential     awsCredentials = null;
+        PropertyBasedS3ClientConfig   awsClientConfig = null;
         if ( commandLine.hasOption(S3_CREDENTIALS) )
         {
             awsCredentials = new PropertyBasedS3Credential(new File(commandLine.getOptionValue(S3_CREDENTIALS)));
         }
 
+        if ( commandLine.hasOption(S3_PROXY) )
+        {
+            awsClientConfig = new PropertyBasedS3ClientConfig(new File(commandLine.getOptionValue(S3_PROXY)));
+        }
+
         BackupProvider backupProvider = null;
         if ( "true".equalsIgnoreCase(commandLine.getOptionValue(S3_BACKUP)) )
         {
-            backupProvider = new S3BackupProvider(new S3ClientFactoryImpl(), awsCredentials, s3Region);
+            backupProvider = new S3BackupProvider(new S3ClientFactoryImpl(), awsCredentials, awsClientConfig, s3Region);
         }
         else if ( "true".equalsIgnoreCase(commandLine.getOptionValue(FILESYSTEMBACKUP)) )
         {
@@ -148,7 +155,7 @@ public class ExhibitorCreator
             throw new MissingConfigurationTypeException("Configuration type (-" + SHORT_CONFIG_TYPE + " or --" + CONFIG_TYPE + ") must be specified", cli);
         }
 
-        ConfigProvider configProvider = makeConfigProvider(configType, cli, commandLine, awsCredentials, backupProvider, useHostname, s3Region);
+        ConfigProvider configProvider = makeConfigProvider(configType, cli, commandLine, awsCredentials, awsClientConfig, backupProvider, useHostname, s3Region);
         if ( configProvider == null )
         {
             throw new ExhibitorCreatorExit(cli);
@@ -271,14 +278,14 @@ public class ExhibitorCreator
         return remoteAuthSpec;
     }
 
-    private ConfigProvider makeConfigProvider(String configType, ExhibitorCLI cli, CommandLine commandLine, PropertyBasedS3Credential awsCredentials, BackupProvider backupProvider, String useHostname, String s3Region) throws Exception
+    private ConfigProvider makeConfigProvider(String configType, ExhibitorCLI cli, CommandLine commandLine, PropertyBasedS3Credential awsCredentials, PropertyBasedS3ClientConfig awsClientConfig, BackupProvider backupProvider, String useHostname, String s3Region) throws Exception
     {
         Properties          defaultProperties = makeDefaultProperties(commandLine, backupProvider);
 
         ConfigProvider      configProvider;
         if ( configType.equals("s3") )
         {
-            configProvider = getS3Provider(cli, commandLine, awsCredentials, useHostname, defaultProperties, s3Region);
+            configProvider = getS3Provider(cli, commandLine, awsCredentials, awsClientConfig, useHostname, defaultProperties, s3Region);
         }
         else if ( configType.equals("file") )
         {
@@ -515,10 +522,10 @@ public class ExhibitorCreator
         return new FileSystemConfigProvider(directory, name, defaultProperties, new AutoManageLockArguments(lockPrefix));
     }
 
-    private ConfigProvider getS3Provider(ExhibitorCLI cli, CommandLine commandLine, PropertyBasedS3Credential awsCredentials, String hostname, Properties defaultProperties, String s3Region) throws Exception
+    private ConfigProvider getS3Provider(ExhibitorCLI cli, CommandLine commandLine, PropertyBasedS3Credential awsCredentials, PropertyBasedS3ClientConfig awsClientConfig, String hostname, Properties defaultProperties, String s3Region) throws Exception
     {
         String  prefix = cli.getOptions().hasOption(S3_CONFIG_PREFIX) ? commandLine.getOptionValue(S3_CONFIG_PREFIX) : DEFAULT_PREFIX;
-        return new S3ConfigProvider(new S3ClientFactoryImpl(), awsCredentials, getS3Arguments(cli, commandLine.getOptionValue(S3_CONFIG), prefix), hostname, defaultProperties, s3Region);
+        return new S3ConfigProvider(new S3ClientFactoryImpl(), awsCredentials, awsClientConfig, getS3Arguments(cli, commandLine.getOptionValue(S3_CONFIG), prefix), hostname, defaultProperties, s3Region);
     }
 
     private void checkMutuallyExclusive(ExhibitorCLI cli, CommandLine commandLine, String option1, String option2) throws ExhibitorCreatorExit


### PR DESCRIPTION
This add an additional command line option which takes a properties file that defines a proxy connection to use when instantiating AmazonS3Client.  The change is backwards compatible.

The version of aws-java-sdk needed to be bumped in order to support this change.

Fixes issue #191 
