### PR TITLE
Changed metrics to reset to 0

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/servo/ZookeeperMonitoredData.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/servo/ZookeeperMonitoredData.java
@@ -100,14 +100,13 @@ public class ZookeeperMonitoredData
         fieldMap = builder.build();
     }
 
-    public void         updateValues(Map<String, Integer> newValues)
-    {
-        for ( Map.Entry<String, Integer> entry : newValues.entrySet() )
-        {
-            AtomicInteger       value = fieldMap.get(entry.getKey());
-            if ( value != null )
-            {
-                value.set(entry.getValue());
+    public void updateValues(Map<String, Integer> newValues) {
+        for (Map.Entry<String, AtomicInteger> entry : fieldMap.entrySet()) {
+            Integer value = newValues.get(entry.getKey());
+            if (value != null) {
+                fieldMap.get(entry.getKey()).set(value);
+            } else {
+                fieldMap.get(entry.getKey()).set(0);
             }
         }
     }

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/servo/TestGetMonitorData.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/servo/TestGetMonitorData.java
@@ -60,7 +60,7 @@ public class TestGetMonitorData
         Assert.assertEquals(zookeeperMonitoredData.zk_packets_received.get(), 1);
         Assert.assertEquals(zookeeperMonitoredData.zk_approximate_data_size.get(), 34);
         Assert.assertEquals(zookeeperMonitoredData.zk_max_file_descriptor_count.get(), 10240);
-        Assert.assertEquals(zookeeperMonitoredData.zk_packets_sent.get(), 10101); // assert that it hasn't changed
+        Assert.assertEquals(zookeeperMonitoredData.zk_packets_sent.get(), 0); // assert that it hasn't changed
     }
 /*
 


### PR DESCRIPTION
This came up when I was trying to figure out of the `zk_followers` and `zk_synced_followers` metrics were correct. A follower should never have those values be non-zero.
