### PR TITLE
Allow use of endpoint URL for S3_REGION

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientImpl.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientImpl.java
@@ -282,8 +282,11 @@ public class S3ClientImpl implements S3Client
 
         if ( s3Region != null )
         {
-            String      fixedRegion = s3Region.equals("us-east-1") ? "" : ("-" + s3Region);
-            String      endpoint = ENDPOINT_SPEC.replace("$REGION$", fixedRegion);
+            String endpoint = s3Region;
+            if (! s3Region.startsWith("http")) {
+                String fixedRegion = s3Region.equals("us-east-1") ? "" : ("-" + s3Region);
+                endpoint = ENDPOINT_SPEC.replace("$REGION$", fixedRegion);
+            }
             localClient.setEndpoint(endpoint);
             log.info("Setting S3 endpoint to: " + endpoint);
         }


### PR DESCRIPTION
This change allows users to pass in a URL rather than a region name for configuring S3. This enables S3 compatible storage systems such as Google Cloud Storage and Eucalyptus to be used as both Backup and configuration storage options.

I am happy to make this to work a different way if the current logic is incorrect in some way.

Thanks for Exhibitor!
