### PR TITLE
Uses monotonic clock to calculate delays

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/activity/ActivityQueue.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/activity/ActivityQueue.java
@@ -39,18 +39,18 @@ public class ActivityQueue implements Closeable
     private static class ActivityHolder implements Delayed
     {
         private final Activity      activity;
-        private final long          endMs;
+        private final long          endNs;
 
         private ActivityHolder(Activity activity, long delayMs)
         {
             this.activity = activity;
-            endMs = System.currentTimeMillis() + delayMs;
+            endNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(delayMs);
         }
 
         @Override
         public long getDelay(TimeUnit unit)
         {
-            return unit.convert(endMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+            return unit.convert(endNs - System.nanoTime(), TimeUnit.NANOSECONDS);
         }
 
         @Override
@@ -62,7 +62,7 @@ public class ActivityQueue implements Closeable
                 return 0;
             }
 
-            long    diff = getDelay(TimeUnit.MILLISECONDS) - rhs.getDelay(TimeUnit.MILLISECONDS);
+            long    diff = getDelay(TimeUnit.NANOSECONDS) - rhs.getDelay(TimeUnit.NANOSECONDS);
             return (diff == 0) ? 0 : ((diff < 0) ? -1 : 1);
         }
 
@@ -86,7 +86,7 @@ public class ActivityQueue implements Closeable
         public int hashCode()
         {
             int result = activity.hashCode();
-            result = 31 * result + (int)(endMs ^ (endMs >>> 32));
+            result = 31 * result + (int)(endNs ^ (endNs >>> 32));
             return result;
         }
     }

--- a/exhibitor-core/src/test/java/com/netflix/exhibitor/core/activity/TestActivityQueue.java
+++ b/exhibitor-core/src/test/java/com/netflix/exhibitor/core/activity/TestActivityQueue.java
@@ -177,7 +177,7 @@ public class TestActivityQueue
     @Test
     public void testRepeating() throws Exception
     {
-        final int DELAY = 500;
+        final int DELAY_MS = 500;
 
         RepeatingActivity       repeating = null;
         ActivityQueue           queue = new ActivityQueue();
@@ -196,15 +196,15 @@ public class TestActivityQueue
                 @Override
                 public Boolean call() throws Exception
                 {
-                    times.add(System.currentTimeMillis());
+                    times.add(System.nanoTime());
                     latch.countDown();
                     return true;
                 }
             };
-            repeating = new RepeatingActivityImpl(null, queue, QueueGroups.MAIN, activity, DELAY);
+            repeating = new RepeatingActivityImpl(null, queue, QueueGroups.MAIN, activity, DELAY_MS);
             repeating.start();
 
-            long                    start = System.currentTimeMillis();
+            long                    start = System.nanoTime();
             Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
             repeating.close();
 
@@ -215,7 +215,7 @@ public class TestActivityQueue
             {
                 long thisTime = times.get(i);
                 long elapsed = thisTime - check;
-                Assert.assertTrue(elapsed >= (DELAY - (DELAY / 10)), "elapsed: " + elapsed);
+                Assert.assertTrue(elapsed >= (DELAY_MS - (DELAY_MS / 10)), "elapsed: " + elapsed);
                 check = thisTime;
             }
         }
@@ -245,16 +245,16 @@ public class TestActivityQueue
                 @Override
                 public Boolean call() throws Exception
                 {
-                    callTime.set(System.currentTimeMillis());
+                    callTime.set(System.nanoTime());
                     latch.countDown();
                     return true;
                 }
             };
 
-            long                    start = System.currentTimeMillis();
+            long                    start = System.nanoTime();
             queue.add(QueueGroups.MAIN, activity, 2, TimeUnit.SECONDS);
             Assert.assertTrue(latch.await(5, TimeUnit.SECONDS));
-            Assert.assertTrue((callTime.get() - start) >= 2000);
+            Assert.assertTrue((callTime.get() - start) >= 2000000);
         }
         finally
         {


### PR DESCRIPTION
In one of the weirder bugs I've ever debugged, users reported that when starting a Vagrant-configured VirtualBox-based virtual machine (VM) that was setup to start Exhibitor on boot, occasionally (but not always) Zookeeper would not start even though the Exhibitor process was running. There wasn't very much log output from Exhibitor. It seemed 'stuck'.

After a hunch that it might be a timing issue, I modified the [upstart](http://upstart.ubuntu.com/) script used to start Exhibitor to save the output of the `date` command to a file.  When the buggy behavior was seen, the value printed by `date` would be 5 hours off. As most programmers who deal with time would also immediately recognize, I knew 5 hours was our current offset from UTC+0 (in `America/New_York` at the time). Timezone issues were immediately suspected.

After some digging, I discovered that Vagrant [always configures VirtualBox to set the real-time clock (RTC) in UTC as a 'sane default'](https://github.com/mitchellh/vagrant/blob/7ceac147daa74b0e9952f8eea7880985180ce6c0/plugins/providers/virtualbox/action/sane_defaults.rb#L18), but our box provisioner ([packer](https://packer.io)) has no such default and we did not configure packer at the time to set the `--rtcuseutc` flag. Without the `--rtcuseutc` flag, the real-time clock is set in local time. And Linux systems (or at least the distribution we are using) persist real-time clock settings to disk on shutdown and use them to populate the software clock on the next boot.

Here's the complete scenario I was able to work out:
- Vagrant imports the base box into VirtualBox.
- Vagrant configures VirtualBox to expose the real-time clock in UTC+0.
- System boots.
- System restores the software clock from the real-time clock, assuming it's in local time (since this is how it was originally provisioned with packer).  This means the software clock is ~5 hours off, because the RTC is actually in UTC.
- Exhibitor starts, and calculates the time it should wait until to start Zookeeper as `System.currentTimeMillis + delay`. Crucially, `System.currentTimeMillis` uses the value from the software clock.
- VirtualBox Guest Additions notices that the software clock is 5 hours off and resets it to the correct time. In our case, this set the software clock 5 hours into the past relative to where it was.
- Exhibitor is now going to wait for 5 hours + the delay, because the return value of `System.currentTimeMillis` has also shifted 5 hours into the past, and the time to wait until was precomputed before the shift.

Users obviously rarely waited 5 hours for Zookeeper to start, instead reporting it as an Exhibitor bug. Restarting the Exhibitor process after boot would also correct the problem since the clock would have stabilized and the delays would be calculated accurately.

Occasionally VirtualBox Guest Additions would correct the time before Exhibitor calculated its delays, and Zookeeper would start normally in those cases.  

It's important to use monotonic clocks when possible to calculate durations.  While this issue is relatively egregious and narrowly focused, durations that use wall-clock time (i.e, `System.currentTimeMillis`) also suffer skew due to leap seconds, large ntp corrections, etc. Monotonic clocks (i.e., `Systems.nanoTime`, at least on platforms that support it like Linux), do not suffer skew because of wall-clock time adjustments.

There are other places in Exhibitor that use `System.currentTimeMillis` to calculate durations, but I chose to focus on just this one area for now in order to gather feedback and keep the changeset small.
