### PR TITLE
Add command line option to listen to a given address

### DIFF
--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCLI.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCLI.java
@@ -88,6 +88,7 @@ public class ExhibitorCLI
     public static final String HELP = "help";
     public static final String ALT_HELP = "?";
     public static final String HTTP_PORT = "port";
+    public static final String LISTEN_ADDRESS = "listenaddress";
     public static final String EXTRA_HEADING_TEXT = "headingtext";
     public static final String NODE_MUTATIONS = "nodemodification";
     public static final String JQUERY_STYLE = "jquerystyle";
@@ -163,6 +164,7 @@ public class ExhibitorCLI
         generalOptions.addOption(null, LOGLINES, true, "Max lines of logging to keep in memory for display. Default is 1000.");
         generalOptions.addOption(null, HOSTNAME, true, "Hostname to use for this JVM. Default is: " + hostname);
         generalOptions.addOption(null, HTTP_PORT, true, "Port for the HTTP Server. Default is: 8080");
+        generalOptions.addOption(null, LISTEN_ADDRESS, true, "Address for the HTTP Server. Default is: 0.0.0.0");
         generalOptions.addOption(null, EXTRA_HEADING_TEXT, true, "Extra text to display in UI header");
         generalOptions.addOption(null, NODE_MUTATIONS, true, "If true, the Explorer UI will allow nodes to be modified (use with caution). Default is true.");
         generalOptions.addOption(null, JQUERY_STYLE, true, "Styling used for the JQuery-based UI. Currently available options: " + getStyleOptions());

--- a/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCreator.java
+++ b/exhibitor-standalone/src/main/java/com/netflix/exhibitor/standalone/ExhibitorCreator.java
@@ -88,6 +88,7 @@ public class ExhibitorCreator
     private final BackupProvider backupProvider;
     private final ConfigProvider configProvider;
     private final int httpPort;
+    private final String listenAddress;
     private final List<Closeable> closeables = Lists.newArrayList();
     private final String securityFile;
     private final String realmSpec;
@@ -146,6 +147,7 @@ public class ExhibitorCreator
         int configCheckMs = Integer.parseInt(commandLine.getOptionValue(CONFIGCHECKMS, "30000"));
         String useHostname = commandLine.getOptionValue(HOSTNAME, cli.getHostname());
         int httpPort = Integer.parseInt(commandLine.getOptionValue(HTTP_PORT, "8080"));
+        String listenAddress = commandLine.getOptionValue(LISTEN_ADDRESS, "0.0.0.0");
         String extraHeadingText = commandLine.getOptionValue(EXTRA_HEADING_TEXT, null);
         boolean allowNodeMutations = "true".equalsIgnoreCase(commandLine.getOptionValue(NODE_MUTATIONS, "true"));
 
@@ -231,6 +233,7 @@ public class ExhibitorCreator
         this.backupProvider = backupProvider;
         this.configProvider = configProvider;
         this.httpPort = httpPort;
+        this.listenAddress = listenAddress;
     }
 
     public ExhibitorArguments.Builder getBuilder()
@@ -241,6 +244,11 @@ public class ExhibitorCreator
     public int getHttpPort()
     {
         return httpPort;
+    }
+    
+    public String getListenAddress()
+    {
+        return listenAddress;
     }
 
     public ConfigProvider getConfigProvider()


### PR DESCRIPTION
Exhibitor currently listens on every interface. This pull request adds a CLI option to only listen on certain addresses. If not specified, Exhibitor will listen on every interface like it previously did. Putting this up for review to see if there is interest/ better ways to do this. 