### PR TITLE
Integrate with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: java
+
+sudo: false
+
+before_script:
+  - export PATH="`pwd`/bin:$PATH"
+  - echo $HOME
+  - echo $JAVA_OPTS
+  - echo $MAVEN_OPTS
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+jdk:
+  - openjdk7
+
+os:
+  - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@ language: java
 
 sudo: false
 
-before_script:
-  - export PATH="`pwd`/bin:$PATH"
-  - echo $HOME
-  - echo $JAVA_OPTS
-  - echo $MAVEN_OPTS
-
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/


### PR DESCRIPTION
This has the same changes as #321 except with a even more minimal setup for travis.
You can view the latest build on my fork on travis here: https://travis-ci.org/xiaochuanyu/exhibitor.

@Randgalt , I believe someone with admin permission need to sign in to travis to enable the actual integration. I think by default, Travis CI will enable for any repo with a `.travis.yml` file in it as soon as you sign in.