### PR TITLE
Support relative path for ZooKeeper

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/Details.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/Details.java
@@ -142,7 +142,7 @@ class Details
 
         if ( (files == null) || (files.length == 0) )
         {
-            throw new IOException("Could not find " + regex + " jar");
+            throw new IOException("Could not find " + regex + " jar in directory " + dir.getAbsolutePath());
         }
 
         Iterable<String> transformed = Iterables.transform

--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/StandardProcessOperations.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/processes/StandardProcessOperations.java
@@ -96,7 +96,7 @@ public class StandardProcessOperations implements ProcessOperations
         Details         details = new Details(exhibitor);
         File            binDirectory = new File(details.zooKeeperDirectory, "bin");
         File            zkServerScript = new File(binDirectory, "zkServer.sh");
-        return new ProcessBuilder(zkServerScript.getPath(), operation).directory(binDirectory.getParentFile());
+        return new ProcessBuilder(zkServerScript.getAbsolutePath(), operation).directory(binDirectory.getParentFile());
     }
 
     @Override


### PR DESCRIPTION
Based off of #169.
Additional changes:
* Added clearer message when log directory path is invalid