### PR TITLE
fix standalone war pom

### DIFF
--- a/exhibitor-standalone/src/main/resources/buildscripts/war/maven/pom.xml
+++ b/exhibitor-standalone/src/main/resources/buildscripts/war/maven/pom.xml
@@ -22,7 +22,7 @@
                 <configuration>
                     <overlays>
                         <overlay>
-                            <groupId>com.netflix.exhibitor</groupId>
+                            <groupId>io.soabase.exhibitor</groupId>
                             <artifactId>exhibitor-standalone</artifactId>
                             <type>jar</type>
                             <includes>


### PR DESCRIPTION
fixes this error when running mvn war:war in exhibitor-standalone/src/main/resources/buildscripts/war/maven

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-war-plugin:2.3:war (default-cli) on project exhibitor-war: overlay [ id com.netflix.exhibitor:exhibitor-standalone] is not a dependency of the project. -> [Help 1]
[ERROR]