### PR TITLE
Log tab XSS fix

### DIFF
--- a/exhibitor-core/src/main/resources/com/netflix/exhibitor/core/ui/js/exhibitor.js
+++ b/exhibitor-core/src/main/resources/com/netflix/exhibitor/core/ui/js/exhibitor.js
@@ -459,7 +459,16 @@ function refreshCurrentTab()
     {
         var index = selected - BUILTIN_TAB_QTY;
         if ( (customTabs[index].type === "simple") || customTabs[index].firstTime ) {
-            $.get(customTabs[index].url, function( data ) { $("#" + customTabs[index].contentId).text(data); });
+            $.get(customTabs[index].url,
+                function( data ) {
+                    var destination = $("#" + customTabs[index].contentId);
+                    if ( customTabs[index].html === true ) {
+                        destination.html(data);
+                    } else {
+                        destination.text(data);
+                    }
+                }
+            );
             customTabs[index].firstTime = false;
         }
     }
@@ -600,6 +609,7 @@ $(function ()
             tabData.contentId = 'tabs-custom-content' + i;
             tabData.url = uiTabSpec[i].url;
             tabData.type = uiTabSpec[i].type;
+            tabData.html = uiTabSpec[i].html;
             tabData.firstTime = true;
             customTabs[i] = tabData;
 

--- a/exhibitor-core/src/main/resources/com/netflix/exhibitor/core/ui/js/exhibitor.js
+++ b/exhibitor-core/src/main/resources/com/netflix/exhibitor/core/ui/js/exhibitor.js
@@ -459,7 +459,7 @@ function refreshCurrentTab()
     {
         var index = selected - BUILTIN_TAB_QTY;
         if ( (customTabs[index].type === "simple") || customTabs[index].firstTime ) {
-            $("#" + customTabs[index].contentId).load(customTabs[index].url);
+            $.get(customTabs[index].url, function( data ) { $("#" + customTabs[index].contentId).text(data); });
             customTabs[index].firstTime = false;
         }
     }


### PR DESCRIPTION
Old: custom tabs' content was 100% considered to be HTML, thanks to jQuery's [load](http://api.jquery.com/load/) method.

The "Log" tab was one such custom tab.

New: custom tabs' content is now either text or HTML, depending on the value of the `UITabSpec` associated with the custom tab.
It should be noted that, with this fix, HTML-intended custom tabs are still potentially vulnerable to cross-site scripting, and must appropriately escape or encode any data they want to output to an HTML context.
