### PR TITLE
allow s3 like storage provider to keep the remote configuration

### DIFF
--- a/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientImpl.java
+++ b/exhibitor-core/src/main/java/com/netflix/exhibitor/core/s3/S3ClientImpl.java
@@ -286,6 +286,10 @@ public class S3ClientImpl implements S3Client
             String      endpoint = ENDPOINT_SPEC.replace("$REGION$", fixedRegion);
             localClient.setEndpoint(endpoint);
             log.info("Setting S3 endpoint to: " + endpoint);
+        } else
+        {
+            localClient.setEndpoint(ENDPOINT_SPEC);
+            log.info("Setting S3 endpoint to: " + ENDPOINT_SPEC);
         }
 
         return localClient;


### PR DESCRIPTION
#378 - a small fix to allow other S3 like storages, tested against http://min.io